### PR TITLE
Implement multi device support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,22 @@ curl --silent https://raw.githubusercontent.com/codeaffen/p3exporter-fritzbox-sm
 If you edit an existing `p3.yml` add the following content to activate the collector.
 
 ```yaml
+exporter_name: "Python prammable Prometheus exporter /w FritzBox collector"
 collectors:
   - p3eFritzBox.collector.smarthome
 collector_opts:
   smarthome:
-    username: smarthome
-    password: v3rys3cr3t
+    defaults:
+      hostname: https://fb.example.com # use this hostname as default (if never set hostname defaults to 'https://fritz.box')
+      username: smarthome # use this username as default
+      ssl_verify: false # disable ssl certificate verification by default
+    devices:
+      - name: FB@home
+        password: v3rys3cr3t
+      - name: FB@cottage
+        password: 4l5ov3rys3cr3t
+        hostname: https://myfritzbox.example.com
+        ssl_verify: true # enable ssl certificate verification for this device connection
 ```
 
 After that you can start the p3exporter as usual:
@@ -70,14 +80,18 @@ INFO:root:Start exporter, listen on 5876
 
 ## Configuration
 
+To configure this collector you need to create a dict with the connection parameters within the `devices` list.
 There are some parameters avaiable to configure the collector. In the following table all parameters are listed.
 
 <!-- markdownlint-disable MD033 MD034 -->
 Name | Default | Mandatory | Description
 --- | --- | --- | ---
+name  | | device_\<NUM\> | An arbitrary name to identify metrics according the device. If not given it will be generated as seen in default column. `<NUM>` stands for the list index, starting with 1.
 username |  | * | Username used to authenticate against FritzBox
 password |  | * | Password used to authenticate against FritzBox
 hostname | https://fritz.box | | Hostname of FritzBox to connect to. Protocol can be `http` or `https`. If no protocol is given default will be `https`.
 device_types | | | List of device type to enable. If List is empty all device types are activated. Possible values are:<br/><ul><li>temperature_sensor</li></ul>
 ssl_verify | True | | Set to `True` to disable ssl certificate verfication. This is useful in case of using self signed certificates.<br/>**Note**: To use this parameter `pyfritzhome` from github is needed as the ssl_verify parameter is not yet available in pypi package. For details use `requirements.txt`.
 <!-- markdownlint-enable MD033 MD034 -->
+
+All parameters from the table above except `name` can also be defined in `defaults` dict. Parameters defined here will be used as defaults for each device in devices list if the corresponding parameter is not defined there.

--- a/p3.yml.example
+++ b/p3.yml.example
@@ -3,7 +3,14 @@ collectors:
   - p3eFritzBox.collector.smarthome
 collector_opts:
   smarthome:
-    username: smarthome
-    password: v3rys3cr3t
-    hostname: https://fritz.box
-    ssl_verify: false
+    defaults:
+      hostname: https://fb.example.com # use this hostname as default (if never set hostname defaults to 'https://fritz.box')
+      username: smarthome # use this username as default
+      ssl_verify: false # disable ssl certificate verification by default
+    devices:
+      - name: FB@home
+        password: v3rys3cr3t
+      - name: FB@cottage
+        password: 4l5ov3rys3cr3t
+        hostname: https://myfritzbox.example.com
+        ssl_verify: true # enable ssl certificate verification for this device connection

--- a/p3eFritzBox/collector/smarthome.py
+++ b/p3eFritzBox/collector/smarthome.py
@@ -49,9 +49,21 @@ class SmarthomeCollector(CollectorBase):
         # top-level connection parameters are deprecated since 1.1.0 and will be removed in 1.2.0
         if 'username' in self.opts or 'password' in self.opts or 'hostname' in self.opts or 'device_types' in self.opts:
             logging.warn('Top-level connection parameters are deprecated and will be removed in version 1.2.0')
-            _legacy_device = dict(name='legacy_device', username=self.opts.pop('username', None), password=self.opts.pop('password', None), hostname=self.opts.pop("hostname", "https://fritz.box"), ssl_verify=self.opts.pop('ssl_verify', True), device_types=self.opts.pop('device_types', []))
+            _legacy_device = dict(
+                name='legacy_device',
+                username=self.opts.pop('username', None),
+                password=self.opts.pop('password', None),
+                hostname=self.opts.pop("hostname", "https://fritz.box"),
+                ssl_verify=self.opts.pop('ssl_verify', True),
+                device_types=self.opts.pop('device_types', [])
+            )
             try:
-                _legacy_device['conn'] = Fritzhome(host=_legacy_device['hostname'], user=_legacy_device['username'], password=_legacy_device['password'], ssl_verify=_legacy_device['ssl_verify'])
+                _legacy_device['conn'] = Fritzhome(
+                    host=_legacy_device['hostname'],
+                    user=_legacy_device['username'],
+                    password=_legacy_device['password'],
+                    ssl_verify=_legacy_device['ssl_verify']
+                )
                 _legacy_device['conn'].login()
             except: # noqa E722
                 raise LoginError(_legacy_device['username'])
@@ -79,13 +91,21 @@ class SmarthomeCollector(CollectorBase):
                 yield fb_dev_info
 
                 if 'temperature_sensor' in device['device_types'] or device['device_types'] == [] and _device.has_temperature_sensor:
-                    fb_temp_gauge = GaugeMetricFamily('p3e_fb_temperatur_sensor', 'Current and target temperature data', labels=['ain', 'device', 'fb_name', 'temperature'])
+                    fb_temp_gauge = GaugeMetricFamily(
+                        'p3e_fb_temperatur_sensor',
+                        'Current and target temperature data',
+                        labels=['ain', 'device', 'fb_name', 'temperature']
+                    )
                     fb_temp_gauge.add_metric([_device.ain, _device.name, dev['fb_name'], 'actual'], _device.actual_temperature)
                     fb_temp_gauge.add_metric([_device.ain, _device.name, dev['fb_name'], 'comfort'], _device.comfort_temperature)
                     fb_temp_gauge.add_metric([_device.ain, _device.name, dev['fb_name'], 'eco'], _device.eco_temperature)
                     yield fb_temp_gauge
 
                 if hasattr(_device, 'battery_level') and hasattr(_device, 'battery_low'):
-                    fb_battery_gauge = GaugeMetricFamily('p3e_fb_battery_status', 'Battery level and status', labels=['ain', 'device', 'fb_name', 'battery_low'])
+                    fb_battery_gauge = GaugeMetricFamily(
+                        'p3e_fb_battery_status',
+                        'Battery level and status',
+                        labels=['ain', 'device', 'fb_name', 'battery_low']
+                    )
                     fb_battery_gauge.add_metric([_device.ain, _device.name, dev['fb_name'], str(_device.battery_low)], _device.battery_level)
                     yield fb_battery_gauge

--- a/p3eFritzBox/collector/smarthome.py
+++ b/p3eFritzBox/collector/smarthome.py
@@ -1,4 +1,6 @@
 """Module that defines all needed classes and functions for example collector."""
+import logging
+
 from p3exporter.collector import CollectorBase, CollectorConfig
 from prometheus_client.core import GaugeMetricFamily, InfoMetricFamily
 
@@ -15,48 +17,75 @@ class SmarthomeCollector(CollectorBase):
         """Instanciate a MyCollector object."""
         super(SmarthomeCollector, self).__init__(config)
 
-        self.username = self.opts.pop("username", "none")
-        self.password = self.opts.pop("password", "none")
-        self.hostname = self.opts.pop("hostname", "https://fritz.box")
-        self.ssl_verify = self.opts.pop("ssl_verify", True)
-        self.device_types = self.opts.pop("device_types", [])
+        # Define connection defaults in a dictionary
+        # Combine connection with user defined defautls
+        self._connection_defaults = dict(username=None, password=None, hostname="https://fritz.box", ssl_verify=True, device_types=[])
+        self.defaults = {**self._connection_defaults, **self.opts.pop("defaults", {})}
+        self.devices = []
 
-        if not self.hostname.startswith('https://') and not self.hostname.startswith('http://'):
-            self.hostname = 'https://' + self.hostname
+        # Create device dictionary, and fix/add some needed data (e.g. device name, protocoll for fritzbox)
+        for (idx, d) in enumerate(self.opts.pop("devices", [])):
+            _d = {**self.defaults, **d}
 
-        try:
-            self._fritzhome = Fritzhome(host=self.hostname, user=self.username, password=self.password, ssl_verify=self.ssl_verify)
-            self._fritzhome.login()
-        except: # noqa E722
-            raise LoginError(self.username)
+            if 'name' not in d:
+                _d['name'] = f"device_{ idx }"
+
+            if not _d['hostname'].startswith('https://') and not _d['hostname'].startswith('http://'):
+                _d['hostname'] = f"https://{ _d['hostname']}"
+
+            if not _d['username'] or not _d['password']:
+                logging.error(f"Username and password are mandatory, device: {_d['name']} ... removed!")
+                continue
+
+            try:
+                _d['conn'] = Fritzhome(host=_d['hostname'], user=_d['username'], password=_d['password'], ssl_verify=_d['ssl_verify'])
+                _d['conn'].login()
+            except: # noqa E722
+                raise LoginError(_d['username'])
+
+            self.devices.append(_d)
+
+        # TODO #7 - Remove legacy code before releasing v1.2.0
+        # top-level connection parameters are deprecated since 1.1.0 and will be removed in 1.2.0
+        if 'username' in self.opts or 'password' in self.opts or 'hostname' in self.opts or 'device_types' in self.opts:
+            logging.warn('Top-level connection parameters are deprecated and will be removed in version 1.2.0')
+            _legacy_device = dict(name='legacy_device', username=self.opts.pop('username', None), password=self.opts.pop('password', None), hostname=self.opts.pop("hostname", "https://fritz.box"), ssl_verify=self.opts.pop('ssl_verify', True), device_types=self.opts.pop('device_types', []))
+            try:
+                _legacy_device['conn'] = Fritzhome(host=_legacy_device['hostname'], user=_legacy_device['username'], password=_legacy_device['password'], ssl_verify=_legacy_device['ssl_verify'])
+                _legacy_device['conn'].login()
+            except: # noqa E722
+                raise LoginError(_legacy_device['username'])
+            self.devices.append(_legacy_device)
 
     def collect(self):
         """Collect the metrics."""
-        devices = self._fritzhome.get_devices()
+        for device in self.devices:
+            smart_devices = device['conn'].get_devices()
 
-        # thermostats
-        for _device in devices:
-            dev = dict(
-                ain=_device.ain,
-                device=_device.name,
-                manufacturer=_device.manufacturer,
-                type=_device.productname,
-                has_thermostat=str(_device.has_thermostat),
-                has_temperature_sendor=str(_device.has_temperature_sensor),
-                has_switch=str(_device.has_switch)
-            )
-            fb_dev_info = InfoMetricFamily('p3e_fb_temperator_sensor', 'FritzBox device information')
-            fb_dev_info.add_metric(labels=dev.keys(), value=dev)
-            yield fb_dev_info
+            # thermostats
+            for _device in smart_devices:
+                dev = dict(
+                    fb_name=device['name'],
+                    ain=_device.ain,
+                    device=_device.name,
+                    manufacturer=_device.manufacturer,
+                    type=_device.productname,
+                    has_thermostat=str(_device.has_thermostat),
+                    has_temperature_sendor=str(_device.has_temperature_sensor),
+                    has_switch=str(_device.has_switch)
+                )
+                fb_dev_info = InfoMetricFamily('p3e_fb_temperator_sensor', 'FritzBox device information')
+                fb_dev_info.add_metric(labels=dev.keys(), value=dev)
+                yield fb_dev_info
 
-            if 'temperature_sensor' in self.device_types or self.device_types == [] and _device.has_temperature_sensor:
-                fb_temp_gauge = GaugeMetricFamily('p3e_fb_temperatur_sensor', 'Current and target temperature data', labels=['ain', 'device', 'temperature'])
-                fb_temp_gauge.add_metric([_device.ain, _device.name, 'actual'], _device.actual_temperature)
-                fb_temp_gauge.add_metric([_device.ain, _device.name, 'comfort'], _device.comfort_temperature)
-                fb_temp_gauge.add_metric([_device.ain, _device.name, 'eco'], _device.eco_temperature)
-                yield fb_temp_gauge
+                if 'temperature_sensor' in device['device_types'] or device['device_types'] == [] and _device.has_temperature_sensor:
+                    fb_temp_gauge = GaugeMetricFamily('p3e_fb_temperatur_sensor', 'Current and target temperature data', labels=['ain', 'device', 'fb_name', 'temperature'])
+                    fb_temp_gauge.add_metric([_device.ain, _device.name, dev['fb_name'], 'actual'], _device.actual_temperature)
+                    fb_temp_gauge.add_metric([_device.ain, _device.name, dev['fb_name'], 'comfort'], _device.comfort_temperature)
+                    fb_temp_gauge.add_metric([_device.ain, _device.name, dev['fb_name'], 'eco'], _device.eco_temperature)
+                    yield fb_temp_gauge
 
-            if hasattr(_device, 'battery_level') and hasattr(_device, 'battery_low'):
-                fb_battery_gauge = GaugeMetricFamily('p3e_fb_battery_status', 'Battery level and status', labels=['ain', 'device', 'battery_low'])
-                fb_battery_gauge.add_metric([_device.ain, _device.name, str(_device.battery_low)], _device.battery_level)
-                yield fb_battery_gauge
+                if hasattr(_device, 'battery_level') and hasattr(_device, 'battery_low'):
+                    fb_battery_gauge = GaugeMetricFamily('p3e_fb_battery_status', 'Battery level and status', labels=['ain', 'device', 'fb_name', 'battery_low'])
+                    fb_battery_gauge.add_metric([_device.ain, _device.name, dev['fb_name'], str(_device.battery_low)], _device.battery_level)
+                    yield fb_battery_gauge


### PR DESCRIPTION
Refactor code to provide ability to connect to more than one Fritz!Box.
For that purpose we refactor also the configuration to map connection
parameters for each Fritz!Box. For convenience purpose we provide a
facility to define defaults for all devices.